### PR TITLE
Main

### DIFF
--- a/Detect-Drives.ps1
+++ b/Detect-Drives.ps1
@@ -1,36 +1,72 @@
-# Liste des partages réseau à vérifier
-$NetworkShares = @{
-    "Names1" = "\\SERVEUR\PATH"
-    "Names2" = @(
- "\\SERVEUR\PATH2",
- "\\SERVEUR\PATH3"
-)
-}
+<#
+.SYNOPSIS
+    Detection script for Intune.
+.DESCRIPTION
+    This script checks if the required network drives, as defined by the main mapping script,
+    are correctly configured. It reads a status file left by the mapping script
+    to get the list of drives that should be present.
+#>
 
-# Récupère les partages réseau actuellement mappés
-try {
-    $MappedShares = Get-WmiObject -Class Win32_NetworkConnection -ErrorAction Stop | Select-Object -ExpandProperty RemoteName
-} catch {
-    Write-Output "Erreur lors de la récupération des connexions réseau."
+# --- Configuration ---
+$StatusFileDirectory = "$env:LOCALAPPDATA\IntuneDriveMapping"
+$StatusFileName = "status.json"
+$StatusFilePath = Join-Path -Path $StatusFileDirectory -ChildPath $StatusFileName
+$MaxAgeHours = 24 # Number of hours before the status is considered outdated
+
+# --- Script Start ---
+
+# Check if the status file exists
+if (-not (Test-Path -Path $StatusFilePath)) {
+    Write-Output "Status file not found at '$StatusFilePath'. Remediation required."
     exit 1
 }
 
-# Aplatissement de toutes les valeurs (simple ou tableau) dans une seule liste
-$AllTargetShares = foreach ($entry in $NetworkShares.GetEnumerator()) {
-    if ($entry.Value -is [Array]) {
-        $entry.Value
-    } else {
-        $entry.Value
+# Read and parse the status file
+$status = Get-Content -Path $StatusFilePath | ConvertFrom-Json
+if (-not $status) {
+    Write-Output "Could not read or parse the status file. Remediation required."
+    exit 1
+}
+
+# Check the age of the status file
+$lastRunTimestamp = [datetime]$status.lastRunTimestamp
+$age = (Get-Date) - $lastRunTimestamp
+if ($age.TotalHours -gt $MaxAgeHours) {
+    Write-Output "Status file is outdated (older than $MaxAgeHours hours). Remediation required."
+    exit 1
+}
+
+# Get currently mapped drives
+try {
+    $mappedDrives = Get-WmiObject -Class Win32_MappedLogicalDisk | Select-Object -ExpandProperty ProviderName
+} catch {
+    Write-Error "Error retrieving mapped drives."
+    exit 1 # Exit with error, Intune will retry later
+}
+
+# Get the list of required drives from the status file
+$requiredUncPaths = $status.requiredDrives
+
+# If no drives are required for this user, detection is successful
+if ($null -eq $requiredUncPaths -or $requiredUncPaths.Count -eq 0) {
+     Write-Output "No network drives are required for this user. Detection successful."
+     exit 0
+}
+
+# Check if all required drives are mapped
+$allDrivesMapped = $true
+foreach ($path in $requiredUncPaths) {
+    if ($mappedDrives -notcontains $path) {
+        Write-Output "Detection: Required drive missing - '$path'"
+        $allDrivesMapped = $false
+        break
     }
 }
 
-# Comparaison avec les connexions actives
-foreach ($share in $AllTargetShares) {
-    if ($MappedShares -contains $share) {
-        Write-Output "Détection réussie : $share est monté."
-        exit 0
-    }
+if ($allDrivesMapped) {
+    Write-Output "Detection: All required drives are mapped."
+    exit 0
+} else {
+    Write-Output "Detection: At least one required drive is missing. Remediation required."
+    exit 1
 }
-
-Write-Output "Aucun lecteur réseau requis n'est monté."
-exit 1

--- a/Map-Drive.ps1
+++ b/Map-Drive.ps1
@@ -1,148 +1,242 @@
-#Final Version 10/06/2025
-# Authentification Entra ID (via App Registration)
-$tenantId = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-$clientId = "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
-$clientSecret = "XXXXXXXXXXXXXXXXXXXXXXXXXXX"
-$resource = "https://graph.microsoft.com/"
-$tokenUri = "https://login.microsoftonline.com/$tenantId/oauth2/v2.0/token"
+<#
+.SYNOPSIS
+    Maps network drives based on Azure AD group membership, with optional Azure Key Vault integration.
+.DESCRIPTION
+    This script, intended for deployment via Intune, determines a user's Azure AD groups,
+    maps corresponding network drives according to a defined configuration, removes old mappings,
+    and creates a status file for the detection script.
+    It can receive secrets directly as parameters or fetch them from an Azure Key Vault.
+.PARAMETER TenantId
+    The Azure AD Tenant ID. Mandatory.
+.PARAMETER Domain
+    The company domain used to construct the user's UPN (e.g., "yourdomain.com"). Mandatory.
+.PARAMETER KeyVaultName
+    Optional. The name of the Azure Key Vault to retrieve secrets from. If used, ClientId and ClientSecret are ignored.
+.PARAMETER ClientId
+    The Client ID of the registered Azure AD application. Mandatory if not using Key Vault.
+.PARAMETER ClientSecret
+    The client secret for the Azure AD application. Mandatory if not using Key Vault.
+#>
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$TenantId,
+    [Parameter(Mandatory=$true)]
+    [string]$Domain,
+    [Parameter(Mandatory=$false)]
+    [string]$KeyVaultName,
+    [Parameter(Mandatory=$false)]
+    [string]$ClientId,
+    [Parameter(Mandatory=$false)]
+    [string]$ClientSecret
+)
 
-$response = Invoke-RestMethod -Method Post -Uri $tokenUri -ContentType "application/x-www-form-urlencoded" -Body @{
-    grant_type    = "client_credentials"
-    client_id     = $clientId
-    client_secret = $clientSecret
-    scope         = "https://graph.microsoft.com/.default"
+# --- Configuration ---
+
+# Filter for searching groups in Graph API. Modify as needed.
+$GroupFilter = "startswith(displayName, 'AZURE/AD_GROUPS')"
+
+# Secret names to look for in Azure Key Vault.
+$ClientIdSecretName = 'IntuneDriveMapper-ClientId'
+$ClientSecretSecretName = 'IntuneDriveMapper-ClientSecret'
+
+# Maps a group name (with wildcard *) to a logical share name.
+$DriveMappings = @{
+    "AZURE/AD_GROUPS*_R1"  = "Finance"
+    "AZURE/AD_GROUPS*_RW1" = "Finance"
+    "AZURE/AD_GROUPS*_R2"  = "HR"
+    "AZURE/AD_GROUPS*_RW2" = "HR"
 }
-$token = $response.access_token
+
+# Maps a logical share name to one or more actual UNC paths.
+$NetworkShares = @{
+    "Finance" = "\\SERVER\\FINANCE"
+    "HR"      = @(
+        "\\SERVER\\HR-DOCS",
+        "\\SERVER\\HR-ARCHIVES"
+    )
+    "Public"  = "\\SERVER\\PUBLIC"
+}
+
+# Status file configuration
+$StatusFileDirectory = "$env:LOCALAPPDATA\IntuneDriveMapping"
+$StatusFileName = "status.json"
+$StatusFilePath = Join-Path -Path $StatusFileDirectory -ChildPath $StatusFileName
+
+# --- Functions ---
+
+function Install-AzModule {
+    param($ModuleName)
+    if (-not (Get-Module -ListAvailable -Name $ModuleName)) {
+        Write-Output "PowerShell module '$ModuleName' not found. Attempting to install..."
+        try {
+            Install-Module -Name $ModuleName -Scope CurrentUser -Repository PSGallery -Force -ErrorAction Stop
+            Write-Output "Module '$ModuleName' installed successfully."
+        } catch {
+            Write-Error "Failed to install module '$ModuleName'. Error: $($_.Exception.Message)"
+            return $false
+        }
+    } else {
+        Write-Output "PowerShell module '$ModuleName' is already installed."
+    }
+    return $true
+}
+
+function Get-SecretsFromKeyVault {
+    Write-Output "Attempting to retrieve secrets from Azure Key Vault '$KeyVaultName'..."
+    if (-not (Install-AzModule -ModuleName Az.Accounts)) { return $null }
+    if (-not (Install-AzModule -ModuleName Az.KeyVault)) { return $null }
+
+    try {
+        Write-Output "Connecting to Azure with user's identity..."
+        Connect-AzAccount -Identity -ErrorAction Stop
+        Write-Output "Successfully connected to Azure."
+    } catch {
+        Write-Error "Failed to connect to Azure using Managed Identity. Ensure the user has an identity and permissions. Error: $($_.Exception.Message)"
+        return $null
+    }
+
+    try {
+        Write-Output "Retrieving secrets from Key Vault..."
+        $kvClientId = (Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $ClientIdSecretName -AsPlainText -ErrorAction Stop)
+        $kvClientSecret = (Get-AzKeyVaultSecret -VaultName $KeyVaultName -Name $ClientSecretSecretName -AsPlainText -ErrorAction Stop)
+        Write-Output "Successfully retrieved secrets from Key Vault."
+        return @{ ClientId = $kvClientId; ClientSecret = $kvClientSecret }
+    } catch {
+        Write-Error "Failed to retrieve secrets from Key Vault '$KeyVaultName'. Check secret names and permissions. Error: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Get-GraphApiToken {
+    param($GatClientId, $GatClientSecret)
+    $tokenUri = "https://login.microsoftonline.com/$TenantId/oauth2/v2.0/token"
+    Write-Output "Getting access token from $tokenUri..."
+    try {
+        $response = Invoke-RestMethod -Method Post -Uri $tokenUri -ContentType "application/x-www-form-urlencoded" -Body @{
+            grant_type    = "client_credentials"
+            client_id     = $GatClientId
+            client_secret = $GatClientSecret
+            scope         = "https://graph.microsoft.com/.default"
+        }
+        Write-Output "Successfully obtained access token."
+        return $response.access_token
+    } catch {
+        Write-Error "Failed to get Graph API access token. Error: $($_.Exception.Message)"
+        return $null
+    }
+}
+
+function Get-AvailableDriveLetter {
+    $reserved = @('A','B','C','D')
+    $usedBySystem = (Get-CimInstance Win32_LogicalDisk).DeviceID | ForEach-Object { $_.TrimEnd(':') }
+    $usedInReg = (Get-ChildItem HKCU:\Network -ErrorAction SilentlyContinue).PSChildName
+    $used = $reserved + $usedBySystem + $usedInReg | Select-Object -Unique
+    $all = [char[]](67..90) # C to Z
+    return $all | Where-Object { $_ -notin $used } | Select-Object -First 1
+}
+
+# --- Script Start ---
+
+Write-Output "Starting drive mapping script."
+
+# 1. Validate parameters and retrieve secrets
+if ($PSBoundParameters.ContainsKey('KeyVaultName')) {
+    $secrets = Get-SecretsFromKeyVault
+    if (-not $secrets) {
+        Write-Error "Could not retrieve secrets from Key Vault. Exiting."
+        exit 1
+    }
+    $ClientId = $secrets.ClientId
+    $ClientSecret = $secrets.ClientSecret
+} elseif (-not ($PSBoundParameters.ContainsKey('ClientId') -and $PSBoundParameters.ContainsKey('ClientSecret'))) {
+    Write-Error "Invalid parameters. You must provide either -KeyVaultName or both -ClientId and -ClientSecret. Exiting."
+    exit 1
+}
+
+# 2. Get Graph API Token
+$token = Get-GraphApiToken -GatClientId $ClientId -GatClientSecret $ClientSecret
+if (-not $token) {
+    exit 1
+}
 
 $headers = @{
     Authorization     = "Bearer $token"
     Consistencylevel  = "eventual"
 }
 
-$localUser = whoami
-$localUserName = $localUser.Split('\')[-1]
-$localUserEmail = "$localUserName@DOMAIN.com"
-
-$userResponse = Invoke-RestMethod -Uri "https://graph.microsoft.com/v1.0/users/$localUserEmail" -Headers $headers -Method Get
-$UserId = $userResponse.id
-
-$groupsUri = "https://graph.microsoft.com/v1.0/users/$UserId/transitiveMemberOf/microsoft.graph.group?`$count=true&`$filter=startswith(displayName, 'AZURE/AD_GROUPS') or startswith(displayName, 'ASYOUWANT')&`$top=999"
-
-$groups = Invoke-RestMethod -Uri $groupsUri -Headers $headers -Method Get
-$groupNames = $groups.value | Where-Object { $_.displayName -like "AZURE/AD_GROUPS*" -or $_.displayName -eq "AZURE/AD_GROUPS*" } | ForEach-Object { $_.displayName }
-
-$DriveMappings = @{
-    "AZURE/AD_GROUPS*_R1"                  = "Names1"
-    "AZURE/AD_GROUPS*_RW1"                 = "Names1"
-    "AZURE/AD_GROUPS*_R2"                  = "Names2"
-    "AZURE/AD_GROUPS*_RW2"                 = "Names2"
-    "AZURE/AD_GROUPS*_RW_DIRECTION"        = "DIRECTION"
-    "AZURE/AD_GROUPS*_R_DIRECTION"         = "DIRECTION"
-
+# 3. Get user's groups
+try {
+    $localUser = $env:USERNAME
+    $userPrincipalName = "$localUser@$Domain"
+    Write-Output "Getting groups for user: $userPrincipalName"
+    $groupsUri = "https://graph.microsoft.com/v1.0/users/$userPrincipalName/transitiveMemberOf/microsoft.graph.group?`$filter=$GroupFilter&`$select=displayName"
+    $groupResponse = Invoke-RestMethod -Uri $groupsUri -Headers $headers -Method Get
+    $userGroupNames = $groupResponse.value.displayName
+    Write-Output "Found groups: $($userGroupNames -join ', ')"
+} catch {
+    Write-Error "Failed to get groups for '$userPrincipalName'. Error: $($_.Exception.Message)"
+    exit 1
 }
 
-$NetworkShares = @{
-    "Names1"                        = "\\SERVEUR\PATH"
-    "Names2" = @( 
-	"\\SERVEUR\PATH2",
-	"\\SERVEUR\PATH3"
-	)
-}
-
-function Get-AvailableDriveLetter {
-    $reservedForDevices = @("A", "B", "C", "D")
-
-
-    $usedBySystem = (Get-CimInstance -ClassName Win32_LogicalDisk | Select-Object -ExpandProperty DeviceID) `
-                    | ForEach-Object { $_.TrimEnd(":") }
-
-
-    $usedInRegistry = @()
-    try {
-        $usedInRegistry = Get-ChildItem -Path "HKCU:\Network" | Select-Object -ExpandProperty PSChildName
-    } catch {
-        # Rien à faire si la clé n'existe pas encore
-    }
-
-    $usedLetters = $usedBySystem + $usedInRegistry + $reservedForDevices
-    $usedLetters = $usedLetters | Select-Object -Unique
-
-    $allLetters = [char[]](67..90 | ForEach-Object { [char]$_ }) # C à Z
-    return $allLetters | Where-Object { $_ -notin $usedLetters } | Select-Object -First 1
-}
-
-
-
-
-$groupsToMount = @()
-
-if ($groupNames -contains 'AZURE/AD_GROUPS*_R_DIRECTION' -or $groupNames -contains 'AZURE/AD_GROUPS*_RW_DIRECTION') {
-    $groupsToMount += $NetworkShares.Keys | Where-Object { $_ -ne 'EXCLUDED_GROUPS' }
-}
-else {
-    # Mapping standard
-    $groupsToMount = $groupNames |
-        ForEach-Object { $DriveMappings[$_] } |
-        Where-Object { $_ } |
-        Select-Object -Unique
-}
-
-
-if (-not ($groupNames -contains 'EXCLUDED_GROUPS') -and -not ($groupsToMount -contains 'PUBLIC')) {
-    $groupsToMount += 'PUBLIC'
-}
-
-
-$allowedShares = @()
-foreach ($group in $groupsToMount) {
-    if ($NetworkShares.ContainsKey($group)) {
-        $paths = $NetworkShares[$group]
-        if ($paths -is [array]) {
-            foreach ($p in $paths) {
-                if ($p -notin $allowedShares) {
-                    $allowedShares += $p
-                }
-            }
-        }
-        elseif ($paths -notin $allowedShares) {
-            $allowedShares += $paths
+# 4. Calculate required shares
+$requiredShareNames = @()
+foreach ($groupName in $userGroupNames) {
+    foreach ($mapping in $DriveMappings.GetEnumerator()) {
+        if ($groupName -like $mapping.Name) {
+            $requiredShareNames += $mapping.Value
         }
     }
 }
-
-
-$mountedDrivesReg = Get-ChildItem -Path 'HKCU:\Network' | ForEach-Object {
-    $drive = $_.PSChildName
-    $remotePath = (Get-ItemProperty -Path $_.PsPath).RemotePath
-    [PSCustomObject]@{ DriveLetter = $drive; RemotePath = $remotePath }
-}
-
-$usedPaths = @{}
-foreach ($entry in $mountedDrivesReg) {
-    if ($allowedShares -notcontains $entry.RemotePath) {
-        Remove-PSDrive -Name $entry.DriveLetter -Force -ErrorAction SilentlyContinue
-    }
-    else {
-        $usedPaths[$entry.RemotePath] = $entry.DriveLetter
+$requiredShareNames += "Public"
+$requiredShareNames = $requiredShareNames | Select-Object -Unique
+$requiredUncPaths = @()
+foreach ($shareName in $requiredShareNames) {
+    if ($NetworkShares.ContainsKey($shareName)) {
+        $paths = $NetworkShares[$shareName]
+        if ($paths -is [array]) { $requiredUncPaths += $paths } else { $requiredUncPaths += $paths }
     }
 }
+$requiredUncPaths = $requiredUncPaths | Select-Object -Unique
+Write-Output "Required UNC paths: $($requiredUncPaths -join ', ')"
 
-
-function Get-AvailableDriveLetter {
-    $reserved = @('A','B','C','D')
-    $usedBySystem = Get-CimInstance Win32_LogicalDisk | Select-Object -Expand DeviceID | ForEach-Object { $_.TrimEnd(':') }
-    $usedInReg = Get-ChildItem HKCU:\Network -ErrorAction SilentlyContinue | Select-Object -Expand PSChildName
-    $used = $reserved + $usedBySystem + $usedInReg | Select-Object -Unique
-    $all = [char[]](67..90 | ForEach-Object {[char]$_})
-    return $all | Where-Object { $_ -notin $used } | Select-Object -First 1
+# 5. Manage existing drives (unmapping)
+$mappedDrives = Get-ChildItem -Path 'HKCU:\Network' -ErrorAction SilentlyContinue | ForEach-Object {
+    [PSCustomObject]@{ DriveLetter = $_.PSChildName; RemotePath  = (Get-ItemProperty -Path $_.PSPath).RemotePath }
+}
+foreach ($drive in $mappedDrives) {
+    if ($requiredUncPaths -notcontains $drive.RemotePath) {
+        Write-Output "Removing drive '$($drive.DriveLetter)' mapped to '$($drive.RemotePath)' as it is no longer required."
+        Remove-PSDrive -Name $drive.DriveLetter -Force -ErrorAction SilentlyContinue
+    }
 }
 
-$currentDrives = Get-CimInstance Win32_LogicalDisk | Where-Object { $_.DriveType -eq 4 } | Select-Object -Expand ProviderName
-
-foreach ($path in $allowedShares) {
-    if ($currentDrives -contains $path) { continue }
+# 6. Map new drives
+$currentlyMappedPaths = (Get-WmiObject -Class Win32_MappedLogicalDisk -ErrorAction SilentlyContinue).ProviderName
+foreach ($path in $requiredUncPaths) {
+    if ($currentlyMappedPaths -contains $path) {
+        Write-Output "Drive for '$path' is already mapped. Skipping."
+        continue
+    }
     $letter = Get-AvailableDriveLetter
     if ($letter) {
-        New-PSDrive -Name $letter -PSProvider FileSystem -Root $path -Persist -ErrorAction SilentlyContinue | Out-Null
+        Write-Output "Mapping '$path' to drive letter '$letter'..."
+        try {
+            New-PSDrive -Name $letter -PSProvider FileSystem -Root $path -Persist -ErrorAction Stop | Out-Null
+        } catch {
+            Write-Error "Failed to map '$path'. Error: $($_.Exception.Message)"
+        }
+    } else {
+        Write-Error "No available drive letter to map '$path'."
     }
 }
+
+# 7. Create the status file
+Write-Output "Creating status file..."
+if (-not (Test-Path -Path $StatusFileDirectory)) {
+    New-Item -Path $StatusFileDirectory -ItemType Directory -Force | Out-Null
+}
+$status = @{ lastRunTimestamp = (Get-Date).ToString("o"); requiredDrives = $requiredUncPaths }
+$status | ConvertTo-Json | Set-Content -Path $StatusFilePath -Encoding UTF8
+
+Write-Output "Drive mapping script finished."
+exit 0

--- a/README.md
+++ b/README.md
@@ -1,129 +1,136 @@
-# Mount-on-prem-Network-Drive-Dynamically
-Abillity to mount on-prem network drive dynamically through powershell and Intune
+# 🗺️ Dynamic Network Drive Mapping with Intune
 
+This project provides a solution to dynamically map on-premises network drives based on a user's Azure AD group membership. The deployment is designed to be managed via Microsoft Intune as a Win32 application.
 
-## Summary
-This solution provides automated mapping of network drives based on the logged-in user's Azure AD group membership. It is designed to be deployed via Microsoft Intune using the Win32 app model and includes:
+## ✨ Summary
 
-A detection script: Verifies if the correct drives are already mapped.
+The solution automates the mapping of network drives for users. It includes:
 
-A remediation script: Automatically maps the required network drives.
+*   **A detection script**: Verifies if the correct network drives are already mapped.
+*   **A remediation script**: Maps the necessary network drives based on the user's Azure AD groups.
 
 ## 🧰 Package Contents
 
-Detect-Drives.ps1 – PowerShell script to detect missing or misconfigured mapped drives.
+*   `Detect-Drives.ps1` – The PowerShell script that detects missing or misconfigured drives.
+*   `Map-Drive.ps1` – The PowerShell script that performs the drive mapping.
 
-Map-Drives.ps1 – PowerShell script that maps drives based on group membership.
+## 🔐 Prerequisite: App Registration in Azure AD
 
-## 🔐 Prerequisite: App Registration in Azure AD
-If the remediation script queries Microsoft Graph API, you must create an App Registration to authenticate and authorize API access.
+For the script to query the Microsoft Graph API, an App Registration is required to authenticate and authorize access.
 
-🔧 Steps to create the App Registration
-Go to Azure Portal > Azure Active Directory > App registrations > + New registration.
+### 🔧 Steps to Create the App Registration
 
-Fill in:
+1.  Go to the **Azure Portal > Azure Active Directory > App registrations > + New registration**.
+2.  Fill in the information:
+    *   **Name**: `IntuneDriveMapper` (or a name of your choice).
+    *   **Supported account types**: Accounts in this organizational directory only (Single tenant).
+3.  Click **Register**.
 
-Name: IntuneDriveMapper (or any name)
+Once the application is created:
 
-Supported account types: Accounts in this organizational directory only (Single tenant)
+4.  Go to **Certificates & secrets > + New client secret**.
+    *   Make a note of the secret's **Value**. It will not be visible again after you leave the page.
+5.  Go to **API Permissions > + Add a permission > Microsoft Graph > Delegated permissions**:
+    *   `GroupMember.Read.All`
+    *   `User.Read`
+6.  Click **Grant admin consent**.
 
-Click Register.
+### 🔑 Information to Collect
 
-Once created:
+Copy the following values to use in the script:
+*   **Tenant ID**
+*   **Application (client) ID**
+*   **Client secret Value**
 
-Go to Certificates & secrets > + New client secret
+## 🔒 Authentication Methods
 
-Note down the secret value (you won’t see it again).
+The script supports two methods for providing the App Registration credentials.
 
-Go to API Permissions > + Add a permission > Microsoft Graph > Delegated permissions:
+### 1. Direct Parameters (Standard Method)
+You can provide the `ClientId` and `ClientSecret` directly as command-line parameters. This is the standard and simplest way to use the script with Intune.
 
-GroupMember.Read.All
+### 2. Azure Key Vault (Advanced Method)
+The script can fetch the credentials from an Azure Key Vault. This is recommended for environments where secrets are centrally managed.
 
-User.Read
-
-Click Grant admin consent.
-
-Copy the following values for your script:
-
-Tenant ID
-
-Client ID
-
-Client Secret
-
-These will be injected securely (e.g., via Intune script parameters or encrypted storage) and used in the remediation script to call Microsoft Graph.
-
-
-
+**Prerequisites for Key Vault:**
+*   The **user** running the script (or the **device**, if using a system identity) must have an Azure AD identity that is granted `Get` access to the secrets in your Key Vault.
+*   The `Az.Accounts` and `Az.KeyVault` PowerShell modules must be available. The script will attempt to install them for the current user if they are missing.
+*   Your Key Vault must contain two secrets with the following **exact names**:
+    *   `IntuneDriveMapper-ClientId` (containing the Application Client ID)
+    *   `IntuneDriveMapper-ClientSecret` (containing the Client Secret value)
 
 ## 🔁 Logic Overview
-Detection script:
 
-Identifies the current user's Azure AD groups.
+*   **Remediation Script (`Map-Drive.ps1`)**:
+    1.  Uses the Microsoft Graph API to retrieve the user's groups.
+    2.  Determines the exact list of required network drives.
+    3.  Maps any missing drives and removes any that are no longer needed.
+    4.  Creates a status file (`status.json`) in a subfolder of the user's local app data (`$env:LOCALAPPDATA`) with the list of drives that were just configured.
 
-Checks if corresponding network drives are correctly mapped.
-
-Returns exit code 0 if everything is correct; 1 otherwise.
-
-Remediation script:
-
-Uses Microsoft Graph API or group translation logic to determine user group membership.
-
-Maps network drives accordingly.
+*   **Detection Script (`Detect-Drives.ps1`)**:
+    1.  Reads the `status.json` file to know which drives should be mapped.
+    2.  Checks if the file is recent (less than 24 hours old by default).
+    3.  Verifies that the drives listed in the file match the currently mapped drives.
+    4.  Exits with code `0` (success) if everything matches, otherwise `1` (failure), which triggers the remediation.
 
 ## 📦 Intune Deployment Instructions
-Step 1 – Prepare the Intune Win32 App Package
-Use the Microsoft Win32 Content Prep Tool to bundle the scripts:
 
+**Step 1 – Prepare the Win32 Package**
 
-Step 2 – Create the Intune App
-In the Microsoft Endpoint Manager Admin Center, go to:
-Apps > Windows > + Add > Windows app (Win32).
+*   Use the `Microsoft Win32 Content Prep Tool` to package the two PowerShell scripts into an `.intunewin` file.
 
-Upload the .intunewin package you created.
+**Step 2 – Create the Application in Intune**
 
-Under Program, configure:
+1.  In the Microsoft Endpoint Manager admin center, go to:
+    **Apps > Windows > + Add > Windows app (Win32)**.
+2.  Upload the `.intunewin` package you created.
+3.  On the **Program** tab, configure the install command. Choose one of the two methods below.
 
-Install command:
+    **Method A: Using Direct Parameters**
+    ```powershell
+    powershell.exe -ExecutionPolicy Bypass -File .\\Map-Drive.ps1 -TenantId "YOUR_TENANT_ID" -Domain "YOUR_DOMAIN.com" -ClientId "YOUR_CLIENT_ID" -ClientSecret "YOUR_SECRET"
+    ```
+    *Replace the placeholders with your actual values.*
 
-powershell
+    **Method B: Using Azure Key Vault**
+    ```powershell
+    powershell.exe -ExecutionPolicy Bypass -File .\\Map-Drive.ps1 -TenantId "YOUR_TENANT_ID" -Domain "YOUR_DOMAIN.com" -KeyVaultName "YOUR_KEY_VAULT_NAME"
+    ```
+    *Replace `YOUR_KEY_VAULT_NAME` with the name of your vault.*
 
-```
-powershell.exe -ExecutionPolicy Bypass -File ".\Map-Drives.ps1"
-```
-Uninstall command: (optional, if you support unmapping)
-
-Under Detection rules, select:
-
-Use a custom script
-
-Upload Detect-Drives.ps1
-
-Configure Requirements, Dependencies, and Assignments as needed.
-
-Don't forget to use "as User" and not as system context
+4.  Configure the uninstall command (optional).
+5.  Under **Detection rules**, select **Use a custom script** and upload `Detect-Drives.ps1`.
+6.  Ensure the application is deployed in the **user context**.
 
 ## ⚙️ Customization
-The mapping logic is stored in Map-Drives.ps1 and may look like:
 
-powershell
+The mapping logic is located in `Map-Drive.ps1`. You can customize it by modifying the hash tables:
 
-```
-$GroupDriveMap = @{
-    "GROUP-FINANCE" = @{ Drive = "Z:"; Path = "\\server\finance" }
-    "GROUP-HR"      = @{ Drive = "Y:"; Path = "\\server\hr" }
+```powershell
+# Maps a group name (with wildcard *) to a logical share name
+$DriveMappings = @{
+    "AZURE/AD_GROUPS*_R1"  = "Finance"
+    "AZURE/AD_GROUPS*_RW1" = "Finance"
+    "AZURE/AD_GROUPS*_R2"  = "HR"
+}
+
+# Maps a logical share name to one or more actual UNC paths
+$NetworkShares = @{
+    "Finance" = "\\SERVER\FINANCE"
+    "HR"      = @(
+        "\\SERVER\HR-DOCS",
+        "\\SERVER\HR-ARCHIVES"
+    )
 }
 ```
-🧪 Testing
-Manually run Detect-Drives.ps1 on a test machine to confirm proper detection logic.
 
-Ensure Intune logs reflect correct remediation if a drive is missing.
+## 🧪 Testing
 
-Use IntuneManagementExtension.log and AgentExecutor.log for troubleshooting.
+*   Manually run `Detect-Drives.ps1` on a test machine to validate the detection logic.
+*   Use the Intune logs (`IntuneManagementExtension.log`, `AgentExecutor.log`) for troubleshooting.
 
-✅ Result
-Fully automated network drive mapping based on Azure AD groups.
+## ✅ Result
 
-Self-healing: if drives are deleted or changed, the detection/remediation cycle will correct it automatically.
-
-Works seamlessly on Hybrid or Azure AD-joined devices.
+*   Fully automated network drive mapping based on Azure AD groups.
+*   Self-healing solution: deleted or modified drives are automatically corrected.
+*   Works on both Azure AD joined and Hybrid joined devices.


### PR DESCRIPTION
This commit fixes a critical bug where the script would attempt to write the `status.json` file to `$env:ProgramData`, a directory that you cannot write to as a standard user.

When deployed via Intune in your user context, this would cause the script to fail with an access denied error.

The fix changes the status file path to a subfolder within `$env:LOCALAPPDATA`, which is the correct, user-writable location for this type of data.

This change has been applied to:
- `Map-Drive.ps1` (where the file is written)
- `Detect-Drives.ps1` (where the file is read)
- `README.md` (to reflect the correct location in the documentation)