### PR TITLE
Fix 401 error by correcting AAD permissions

### DIFF
--- a/Map-Drive.ps1
+++ b/Map-Drive.ps1
@@ -174,7 +174,12 @@ try {
     $userGroupNames = $groupResponse.value.displayName
     Write-Output "Found groups: $($userGroupNames -join ', ')"
 } catch {
-    Write-Error "Failed to get groups for '$userPrincipalName'. Error: $($_.Exception.Message)"
+    $errorMessage = $_.Exception.Message
+    if ($errorMessage -like "*401*" -or $errorMessage -like "*Unauthorized*") {
+        Write-Error "Failed to get groups for '$userPrincipalName'. The server returned a 401 Unauthorized error. This is likely due to incorrect API permissions on the Azure AD App Registration. Please ensure the application has the 'GroupMember.Read.All' and 'User.Read.All' APPLICATION permissions and that admin consent has been granted. Refer to the README.md for instructions."
+    } else {
+        Write-Error "Failed to get groups for '$userPrincipalName'. Error: $errorMessage"
+    }
     exit 1
 }
 

--- a/README.md
+++ b/README.md
@@ -30,10 +30,12 @@ Once the application is created:
 
 4.  Go to **Certificates & secrets > + New client secret**.
     *   Make a note of the secret's **Value**. It will not be visible again after you leave the page.
-5.  Go to **API Permissions > + Add a permission > Microsoft Graph > Delegated permissions**:
-    *   `GroupMember.Read.All`
-    *   `User.Read`
-6.  Click **Grant admin consent**.
+5.  Go to **API Permissions > + Add a permission > Microsoft Graph > Application permissions**:
+    *   `GroupMember.Read.All` – Allows the app to read group memberships.
+    *   `User.Read.All` – Allows the app to read basic properties of all users.
+    > **Note:** The script uses application permissions (app-only context) and not delegated permissions. Ensure you are adding the correct type.
+
+6.  Click **Grant admin consent for [Your Tenant]**. This step is crucial and must be performed by an administrator.
 
 ### 🔑 Information to Collect
 


### PR DESCRIPTION
You were encountering a 401 Unauthorized error when your script tried to fetch user groups from the Microsoft Graph API.

This was caused by incorrect instructions in the README.md, which specified Delegated permissions instead of the required Application permissions for the client credentials flow used in the script.

To resolve this, I've made two main changes:
1.  I updated README.md to specify the correct Application permissions (`GroupMember.Read.All`, `User.Read.All`) and to emphasize the need for admin consent.
2.  I improved the error handling in `Map-Drive.ps1` to provide a more specific error message on a 401 failure, guiding you to check the application permissions.