### PR TITLE
Fix Graph API query for group memberships

### DIFF
--- a/Map-Drive.ps1
+++ b/Map-Drive.ps1
@@ -169,10 +169,22 @@ try {
     $localUser = $env:USERNAME
     $userPrincipalName = "$localUser@$Domain"
     Write-Output "Getting groups for user: $userPrincipalName"
-    $groupsUri = "https://graph.microsoft.com/v1.0/users/$userPrincipalName/transitiveMemberOf/microsoft.graph.group?`$filter=$GroupFilter&`$select=displayName"
+
+    # The 'transitiveMemberOf' endpoint does not support $filter. Groups must be filtered client-side.
+    $groupsUri = "https://graph.microsoft.com/v1.0/users/$userPrincipalName/transitiveMemberOf/microsoft.graph.group?`$select=displayName&`$top=999"
     $groupResponse = Invoke-RestMethod -Uri $groupsUri -Headers $headers -Method Get
-    $userGroupNames = $groupResponse.value.displayName
-    Write-Output "Found groups: $($userGroupNames -join ', ')"
+
+    # Convert the Graph API filter string to a PowerShell wildcard pattern.
+    # e.g., "startswith(displayName, 'AZURE/AD_GROUPS')" becomes "AZURE/AD_GROUPS*"
+    $wildcardPattern = $GroupFilter.Replace("startswith(displayName, '", "").Replace("')", "*")
+
+    $userGroupNames = $groupResponse.value | Where-Object { $_.displayName -like $wildcardPattern } | Select-Object -ExpandProperty displayName
+
+    if ($userGroupNames) {
+        Write-Output "Found matching groups: $($userGroupNames -join ', ')"
+    } else {
+        Write-Output "User is not a member of any matching groups."
+    }
 } catch {
     $errorMessage = $_.Exception.Message
     if ($errorMessage -like "*401*" -or $errorMessage -like "*Unauthorized*") {


### PR DESCRIPTION
The 'transitiveMemberOf' Graph API endpoint does not support the '$filter' parameter. The previous implementation was using this parameter, causing the API call to fail.

This commit refactors the group retrieval logic to:
1.  Remove the unsupported '$filter' from the Graph API query.
2.  Fetch the complete list of your group memberships.
3.  Perform the filtering on the client-side using PowerShell's `Where-Object`, which achieves the same result without making an invalid API call.

This change aligns with the Graph API's capabilities and resolves the script's primary functional bug.